### PR TITLE
fix: json_decode exception when dat file not exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 vendor/
 tools/
 examples/.dat

--- a/examples/templates/base.php
+++ b/examples/templates/base.php
@@ -88,7 +88,7 @@ function setData($key, $value)
     $file = __DIR__ . '/../.dat';
     $content = file_get_contents($file);
     if (!$content) {
-      $content = array();
+      $content = "{}";
     }
     $content = json_decode($content);
     $content->{$key} = $value;


### PR DESCRIPTION
```bash
POST /index.php - Uncaught TypeError: json_decode(): Argument #1 ($json) must be of type string, array given in /home/owen/Document/github/app-store-connect-api-php/examples/templates/base.php:94
Stack trace:
#0 /home/owen/Document/github/app-store-connect-api-php/examples/templates/base.php(94): json_decode()
#1 /home/owen/Document/github/app-store-connect-api-php/examples/index.php(15): setData()
#2 {main}
  thrown in /home/owen/文档/github/app-store-connect-api-php/examples/templates/base.php on line 94
```