### PR TITLE
Update firebase/php-jwt to support ^7.0 and fix nullable parameter deprecation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": "^7.4|^8.0",
         "google/auth": "^1.28",
         "guzzlehttp/guzzle": "^7.0.1",
-        "firebase/php-jwt": "~6.0",
+        "firebase/php-jwt": "^6.0||^7.0",
         "monolog/monolog": "^2.9||^3.0"
     },
     "autoload": {

--- a/src/Http/REST.php
+++ b/src/Http/REST.php
@@ -103,7 +103,7 @@ class REST
    */
   public static function decodeHttpResponse(
       ResponseInterface $response,
-      RequestInterface $request = null,
+      ?RequestInterface $request = null,
       $expectedClass = null
   ) {
     $code = $response->getStatusCode();
@@ -130,7 +130,7 @@ class REST
     return $response;
   }
 
-  private static function decodeBody(ResponseInterface $response, RequestInterface $request = null)
+  private static function decodeBody(ResponseInterface $response, ?RequestInterface $request = null)
   {
     if (self::isAltMedia($request)) {
       // don't decode the body, it's probably a really long string
@@ -140,7 +140,7 @@ class REST
     return (string) $response->getBody();
   }
 
-  private static function determineExpectedClass($expectedClass, RequestInterface $request = null)
+  private static function determineExpectedClass($expectedClass, ?RequestInterface $request = null)
   {
     // "false" is used to explicitly prevent an expected class from being returned
     if (false === $expectedClass) {
@@ -163,7 +163,7 @@ class REST
     return new $expectedClass($json);
   }
 
-  private static function isAltMedia(RequestInterface $request = null)
+  private static function isAltMedia(?RequestInterface $request = null)
   {
     if ($request && $qs = $request->getUri()->getQuery()) {
       parse_str($qs, $query);


### PR DESCRIPTION
- Updated firebase/php-jwt constraint to "^6.0 || ^7.0" for security fixes while 
  maintaining backward compatibility with 6.x.
- Refactored REST.php methods to use explicit nullable parameters and avoid 
  deprecation warnings:
    • decodeHttpResponse()
    • decodeBody()
    • determineExpectedClass()
    • isAltMedia()
- No breaking changes; JWT::encode behavior is compatible with both 6.x and 7.x.